### PR TITLE
feat: allow users to change password

### DIFF
--- a/src/lib/api/services/userService.ts
+++ b/src/lib/api/services/userService.ts
@@ -29,3 +29,13 @@ export async function resendInvitation(userId: string | number) {
   await apiClient.post(`/users/${userId}/resend-invitation`, {}, { withCredentials: true });
   return true;
 }
+
+export const changePassword = async (
+  currentPassword: string,
+  newPassword: string
+): Promise<void> => {
+  await apiClient.post('/users/change-password', {
+    currentPassword,
+    newPassword,
+  });
+};


### PR DESCRIPTION
## Summary
- add `changePassword` API service
- add password update form in settings page with validation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6c5787b288330bde74c16603f6079