### PR TITLE
docs: add integration tasks for missing endpoints

### DIFF
--- a/docs/integration-tasks.md
+++ b/docs/integration-tasks.md
@@ -1,0 +1,18 @@
+# Integration Tasks
+
+Review of existing API services and UI usage identified the following discrepancies requiring additional integration work.
+
+## Missing Endpoints
+
+- **Change User Password**: Endpoint documented in API specification but not implemented in services or UI (`POST /api/users/change-password`).
+- **Maintenance Records**:
+  - Specification exposes `/api/maintenance` (GET, POST) and `/api/maintenance/{id}` (GET, PUT, DELETE), while current frontend only posts to `/equipment/{id}/maintenance` for creation.
+- **Notifications Management**:
+  - Endpoints `/api/notifications/{id}/read` (PUT) and `/api/notifications/{id}` (DELETE) lack corresponding service functions and UI actions.
+
+## Proposed Tasks
+
+1. Add service methods and UI workflows for changing a user's password.
+2. Align maintenance record operations with the API specification and implement missing list, detail, update and delete functionality.
+3. Implement notification management features (mark as read, delete) in services and user interface.
+


### PR DESCRIPTION
## Summary
- document missing API integrations for user password change, maintenance records, and notifications management

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c5885c448330a9e0309b37dd6f39