### PR TITLE
feat: add read and delete notification actions

### DIFF
--- a/src/lib/api/services/notificationService.ts
+++ b/src/lib/api/services/notificationService.ts
@@ -4,4 +4,13 @@ import { AppNotification } from '@/types';
 export const getNotifications = async (): Promise<AppNotification[]> => {
   const response = await apiClient.get('/notifications');
   return response.data;
-}; 
+};
+
+export const markAsRead = async (id: string): Promise<AppNotification> => {
+  const response = await apiClient.put(`/notifications/${id}/read`);
+  return response.data;
+};
+
+export const deleteNotification = async (id: string): Promise<void> => {
+  await apiClient.delete(`/notifications/${id}`);
+};


### PR DESCRIPTION
## Summary
- add notification service helpers to mark as read and delete
- enable marking and removing notifications from header with visual feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c579f5548330a62b42bd0b24d3cd