### PR TITLE
feat: add maintenance service and integrate with equipment

### DIFF
--- a/src/lib/api/services/equipmentService.ts
+++ b/src/lib/api/services/equipmentService.ts
@@ -1,5 +1,9 @@
 import apiClient from '@/lib/api/client/apiClient';
 import { Equipment } from '@/types';
+import {
+  createMaintenanceRecord as createMaintenanceRecordApi,
+  MaintenanceRecordRequest,
+} from './maintenanceService';
 
 // Tipo para la respuesta del backend (DTO)
 export interface EquipmentResponse {
@@ -60,10 +64,12 @@ export const checkInstitutionalIdExists = async (institutionalId: string): Promi
   return response.data;
 };
 
-export const createMaintenanceRecord = async (equipmentId: string, maintenanceData: FormData): Promise<void> => {
-  await apiClient.post(`/equipment/${equipmentId}/maintenance`, maintenanceData, {
-    headers: {
-      'Content-Type': 'multipart/form-data',
-    },
+export const createMaintenanceRecord = async (
+  equipmentId: string,
+  maintenanceData: Omit<MaintenanceRecordRequest, 'equipment'>
+): Promise<void> => {
+  await createMaintenanceRecordApi({
+    ...maintenanceData,
+    equipment: { id: equipmentId },
   });
-}; 
+};

--- a/src/lib/api/services/maintenanceService.ts
+++ b/src/lib/api/services/maintenanceService.ts
@@ -1,0 +1,38 @@
+import apiClient from '@/lib/api/client/apiClient';
+import { MaintenanceRecord } from '@/types';
+
+export interface MaintenanceRecordRequest
+  extends Omit<MaintenanceRecord, 'id' | 'attachments'> {
+  equipment: { id: string | number };
+  attachments?: { name: string; url: string }[];
+}
+
+export const getMaintenanceRecords = async (): Promise<MaintenanceRecord[]> => {
+  const response = await apiClient.get('/maintenance');
+  return response.data;
+};
+
+export const getMaintenanceRecordById = async (id: string): Promise<MaintenanceRecord> => {
+  const response = await apiClient.get(`/maintenance/${id}`);
+  return response.data;
+};
+
+export const createMaintenanceRecord = async (
+  record: MaintenanceRecordRequest
+): Promise<MaintenanceRecord> => {
+  const response = await apiClient.post('/maintenance', record);
+  return response.data;
+};
+
+export const updateMaintenanceRecord = async (
+  id: string,
+  record: Partial<MaintenanceRecordRequest>
+): Promise<MaintenanceRecord> => {
+  const response = await apiClient.put(`/maintenance/${id}`, record);
+  return response.data;
+};
+
+export const deleteMaintenanceRecord = async (id: string): Promise<void> => {
+  await apiClient.delete(`/maintenance/${id}`);
+};
+


### PR DESCRIPTION
## Summary
- add maintenanceService with CRUD helpers for maintenance API
- delegate maintenance record creation to maintenanceService using JSON requests
- refresh equipment detail page via maintenance service and remove file upload

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c579350c8330a3df50591cda96f5