### PR TITLE
Send equipment object in issue reports

### DIFF
--- a/src/app/(admin)/admin/DashboardPage.tsx
+++ b/src/app/(admin)/admin/DashboardPage.tsx
@@ -52,14 +52,14 @@ const DashboardPage: React.FC = () => {
         if (currentUser?.role === UserRole.UNIT_MANAGER && currentUser.unit) {
             const filteredEquipment = allEquipment.filter(eq => eq.locationUnit === currentUser.unit);
             const filteredEquipmentIds = filteredEquipment.map(eq => eq.id.toString());
-            const filteredIssues = allIssues.filter(issue => filteredEquipmentIds.includes(issue.equipmentId));
+            const filteredIssues = allIssues.filter(issue => filteredEquipmentIds.includes(issue.equipment.id));
             return { equipment: filteredEquipment, issues: filteredIssues };
         }
         // Si es Encargado, filtra por los equipos asignados a su usuario
         else if (currentUser?.role === UserRole.EQUIPMENT_MANAGER && currentUser.id) {
             const filteredEquipment = allEquipment.filter(eq => eq.encargado && eq.encargado.id === parseInt(currentUser.id));
             const filteredEquipmentIds = filteredEquipment.map(eq => eq.id.toString());
-            const filteredIssues = allIssues.filter(issue => filteredEquipmentIds.includes(issue.equipmentId));
+            const filteredIssues = allIssues.filter(issue => filteredEquipmentIds.includes(issue.equipment.id));
             return { equipment: filteredEquipment, issues: filteredIssues };
         }
         // Si es admin, ve todos los datos
@@ -129,8 +129,9 @@ const DashboardPage: React.FC = () => {
             issueCounts[eq.id] = { name: eq.name, count: 0 };
         });
         userFilteredData.issues.forEach(issue => {
-            if (issueCounts[issue.equipmentId]) {
-                issueCounts[issue.equipmentId].count++;
+            const eqId = issue.equipment.id;
+            if (issueCounts[eqId]) {
+                issueCounts[eqId].count++;
             }
         });
         return Object.values(issueCounts)

--- a/src/app/(admin)/admin/IssuesListPage.tsx
+++ b/src/app/(admin)/admin/IssuesListPage.tsx
@@ -87,7 +87,7 @@ const IssuesListPage: React.FC = () => {
             const unitEquipmentIds = allEquipment
                 .filter((eq: any) => eq.locationUnit === currentUser.unit)
                 .map((eq: any) => eq.id);
-            tempIssues = tempIssues.filter(issue => unitEquipmentIds.includes(issue.equipmentId));
+            tempIssues = tempIssues.filter(issue => unitEquipmentIds.includes(issue.equipment.id));
         }
 
         setFilteredIssues(tempIssues);
@@ -211,7 +211,7 @@ const IssuesListPage: React.FC = () => {
                             <tbody className="bg-white divide-y divide-gray-200">
                             {filteredIssues.length > 0 ? filteredIssues.map(issue => (
                                 <tr key={issue.id}>
-                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{issue.equipmentName || issue.equipmentId}</td>
+                                    <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{issue.equipment?.name || issue.equipment?.id}</td>
                                     <td className="px-6 py-4 whitespace-normal text-sm text-gray-500 max-w-xs truncate">{issue.description}</td>
                                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{issue.reportedBy}</td>
                                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{format(new Date(issue.dateTime), 'PPpp', { locale: es })}</td>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,8 +74,7 @@ export enum IssueSeverity {
 
 export interface IssueReport {
   id: string;
-  equipmentId: string;
-  equipmentName: string;
+  equipment: Equipment;
   reportedBy: string; // User name or ID
   dateTime: string; // ISO string
   description: string;


### PR DESCRIPTION
## Summary
- Represent issue reports with full `equipment` object instead of separate id/name
- Update issue form, issue list, and dashboard to handle embedded equipment data

## Testing
- `npm run build`
- `./mvnw -q test` *(fails: Non-resolvable parent POM for cl.ufro:bioren_backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c5c86f7c8330840d45d94aaa4993