### PR TITLE
feat: allow issue creation without id

### DIFF
--- a/src/app/(admin)/admin/ReportIssuePage.tsx
+++ b/src/app/(admin)/admin/ReportIssuePage.tsx
@@ -15,20 +15,16 @@ const ReportIssuePage: React.FC = () => {
   const queryParams = new URLSearchParams(location.search);
   const equipmentIdFromUrl = queryParams.get('equipmentId') || undefined;
 
-  const handleSubmitIssue = async (issueReportData: Omit<IssueReport, 'id' | 'dateTime' | 'reportedBy'>) => {
+  const handleSubmitIssue = async (issueReportData: Omit<IssueReport, 'id'> & { id?: string }) => {
     if (!currentUser) {
       alert("Error: Debes estar logueado para reportar una incidencia.");
       return;
     }
 
-    // Completamos los datos de la incidencia con la información del usuario logueado
-    const fullIssueReport = {
-      ...issueReportData,
-      reportedBy: currentUser.name,
-    };
+    const { id: _id, ...dataWithoutId } = issueReportData;
 
     try {
-      await createIssueReport(fullIssueReport);
+      await createIssueReport(dataWithoutId);
       alert('¡Incidencia reportada exitosamente!');
       navigate('/issues'); // Redirigimos a la lista de incidencias
 

--- a/src/features/admin/components/issues/IssueReportForm.tsx
+++ b/src/features/admin/components/issues/IssueReportForm.tsx
@@ -11,10 +11,12 @@ import { useAuth } from '@/hooks/useAuth';
 import { getEquipments, EquipmentResponse } from '@/lib/api/services/equipmentService';
 import { useToast } from '@/hooks/useToast';
 
+type IssueReportInput = Omit<IssueReport, 'id'> & { id?: string };
+
 interface IssueReportFormProps {
     initialData?: IssueReport | null;
     equipmentIdFromUrl?: string;
-    onSubmit: (issueReport: IssueReport) => void;
+    onSubmit: (issueReport: IssueReportInput) => void;
     onCancel: () => void;
 }
 
@@ -162,8 +164,7 @@ const IssueReportForm: React.FC<IssueReportFormProps> = ({ initialData, equipmen
                 toast.showToast('Equipo no encontrado.');
                 return;
             }
-            const finalData: IssueReport = {
-                id: formData.id || '',
+            const finalData: Omit<IssueReport, 'id'> = {
                 equipment: selectedEquipment,
                 reportedBy: currentUser?.id || '',
                 dateTime: new Date().toISOString(),
@@ -172,7 +173,11 @@ const IssueReportForm: React.FC<IssueReportFormProps> = ({ initialData, equipmen
                 status: formData.status,
                 attachments: formData.attachments,
             };
-            onSubmit(finalData);
+            if (formData.id) {
+                onSubmit({ ...finalData, id: formData.id });
+            } else {
+                onSubmit(finalData);
+            }
         }
     };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,7 +73,7 @@ export enum IssueSeverity {
 }
 
 export interface IssueReport {
-  id: string;
+  id?: string;
   equipment: Equipment;
   reportedBy: string; // User name or ID
   dateTime: string; // ISO string


### PR DESCRIPTION
## Summary
- make `IssueReport` id optional
- submit issue reports without id and attach id only when editing
- accept issue submissions without id on admin page

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "@tanstack/react-query")*

------
https://chatgpt.com/codex/tasks/task_e_68ac78de40ec8330afc3f46fe301937e