### PR TITLE
feat: add compose for frontend and backend

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,22 @@
 services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./bioren_backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mariadb
+
   mariadb:
     image: mariadb:latest
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Docker Compose configuration for frontend, backend, and MariaDB

## Testing
- `docker compose config` *(fails: command not found)*
- `npm run build`
- `cd bioren_backend && ./mvnw -q package -DskipTests` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68ace68a0c5c833089f2a9a14436259f